### PR TITLE
Added logic for temporary development customizations.

### DIFF
--- a/CustomizationEditor_10.1.500/NonModalWokIt.Designer.cs
+++ b/CustomizationEditor_10.1.500/NonModalWokIt.Designer.cs
@@ -95,7 +95,6 @@
             this.btnTest.TabIndex = 4;
             this.btnTest.Text = "Run (Test)";
             this.btnTest.UseVisualStyleBackColor = true;
-            this.btnTest.Visible = false;
             this.btnTest.Click += new System.EventHandler(this.btnTest_Click);
             // 
             // btnDebug

--- a/CustomizationEditor_10.1.500/NonModalWokIt.cs
+++ b/CustomizationEditor_10.1.500/NonModalWokIt.cs
@@ -69,12 +69,11 @@ namespace CustomizationEditor
 
         private void btnTest_Click(object sender, EventArgs e)
         {
-            if (chkSyncUp.Checked)
-            {
-                l.UpdateCustomization(o, (Session)this.session);
-            }
-
+            string tempId = "_" + Guid.NewGuid().ToString().Substring(0, o.Key1.Length - 1);
+            l.CreateTemporaryCustomization(o, (Session)this.session, tempId);
+            o.Key1 = o.Key1 + tempId;
             l.LaunchInEpicor(o, (Session)this.session, false, false);
+            l.DeleteTemporaryCustomization(o, (Session)this.session, tempId);
             Thread.Sleep(1000);
             CheckTM();
         }

--- a/CustomizationEditor_10.1.600/NonModalWokIt.Designer.cs
+++ b/CustomizationEditor_10.1.600/NonModalWokIt.Designer.cs
@@ -95,7 +95,6 @@
             this.btnTest.TabIndex = 4;
             this.btnTest.Text = "Run (Test)";
             this.btnTest.UseVisualStyleBackColor = true;
-            this.btnTest.Visible = false;
             this.btnTest.Click += new System.EventHandler(this.btnTest_Click);
             // 
             // btnDebug

--- a/CustomizationEditor_10.1.600/NonModalWokIt.cs
+++ b/CustomizationEditor_10.1.600/NonModalWokIt.cs
@@ -69,12 +69,11 @@ namespace CustomizationEditor
 
         private void btnTest_Click(object sender, EventArgs e)
         {
-            if (chkSyncUp.Checked)
-            {
-                l.UpdateCustomization(o, (Session)this.session);
-            }
-
+            string tempId = "_" + Guid.NewGuid().ToString().Substring(0, o.Key1.Length - 1);
+            l.CreateTemporaryCustomization(o, (Session)this.session, tempId);
+            o.Key1 = o.Key1 + tempId;
             l.LaunchInEpicor(o, (Session)this.session, false, false);
+            l.DeleteTemporaryCustomization(o, (Session)this.session, tempId);
             Thread.Sleep(1000);
             CheckTM();
         }

--- a/CustomizationEditor_10.2.100/NonModalWokIt.Designer.cs
+++ b/CustomizationEditor_10.2.100/NonModalWokIt.Designer.cs
@@ -95,7 +95,6 @@
             this.btnTest.TabIndex = 4;
             this.btnTest.Text = "Run (Test)";
             this.btnTest.UseVisualStyleBackColor = true;
-            this.btnTest.Visible = false;
             this.btnTest.Click += new System.EventHandler(this.btnTest_Click);
             // 
             // btnDebug

--- a/CustomizationEditor_10.2.100/NonModalWokIt.cs
+++ b/CustomizationEditor_10.2.100/NonModalWokIt.cs
@@ -69,12 +69,11 @@ namespace CustomizationEditor
 
         private void btnTest_Click(object sender, EventArgs e)
         {
-            if (chkSyncUp.Checked)
-            {
-                l.UpdateCustomization(o, (Session)this.session);
-            }
-
+            string tempId = "_" + Guid.NewGuid().ToString().Substring(0, o.Key1.Length - 1);
+            l.CreateTemporaryCustomization(o, (Session)this.session, tempId);
+            o.Key1 = o.Key1 + tempId;
             l.LaunchInEpicor(o, (Session)this.session, false, false);
+            l.DeleteTemporaryCustomization(o, (Session)this.session, tempId);
             Thread.Sleep(1000);
             CheckTM();
         }

--- a/CustomizationEditor_10.2.200/NonModalWokIt.Designer.cs
+++ b/CustomizationEditor_10.2.200/NonModalWokIt.Designer.cs
@@ -95,7 +95,6 @@
             this.btnTest.TabIndex = 4;
             this.btnTest.Text = "Run (Test)";
             this.btnTest.UseVisualStyleBackColor = true;
-            this.btnTest.Visible = false;
             this.btnTest.Click += new System.EventHandler(this.btnTest_Click);
             // 
             // btnDebug

--- a/CustomizationEditor_10.2.200/NonModalWokIt.cs
+++ b/CustomizationEditor_10.2.200/NonModalWokIt.cs
@@ -69,12 +69,11 @@ namespace CustomizationEditor
 
         private void btnTest_Click(object sender, EventArgs e)
         {
-            if (chkSyncUp.Checked)
-            {
-                l.UpdateCustomization(o, (Session)this.session);
-            }
-
+            string tempId = "_" + Guid.NewGuid().ToString().Substring(0, o.Key1.Length - 1);
+            l.CreateTemporaryCustomization(o, (Session)this.session, tempId);
+            o.Key1 = o.Key1 + tempId;
             l.LaunchInEpicor(o, (Session)this.session, false, false);
+            l.DeleteTemporaryCustomization(o, (Session)this.session, tempId);
             Thread.Sleep(1000);
             CheckTM();
         }

--- a/CustomizationEditor_10.2.300/NonModalWokIt.Designer.cs
+++ b/CustomizationEditor_10.2.300/NonModalWokIt.Designer.cs
@@ -95,7 +95,6 @@
             this.btnTest.TabIndex = 4;
             this.btnTest.Text = "Run (Test)";
             this.btnTest.UseVisualStyleBackColor = true;
-            this.btnTest.Visible = false;
             this.btnTest.Click += new System.EventHandler(this.btnTest_Click);
             // 
             // btnDebug

--- a/CustomizationEditor_10.2.300/NonModalWokIt.cs
+++ b/CustomizationEditor_10.2.300/NonModalWokIt.cs
@@ -69,12 +69,11 @@ namespace CustomizationEditor
 
         private void btnTest_Click(object sender, EventArgs e)
         {
-            if (chkSyncUp.Checked)
-            {
-                l.UpdateCustomization(o, (Session)this.session);
-            }
-
+            string tempId = "_" + Guid.NewGuid().ToString().Substring(0, o.Key1.Length - 1);
+            l.CreateTemporaryCustomization(o, (Session)this.session, tempId);
+            o.Key1 = o.Key1 + tempId;
             l.LaunchInEpicor(o, (Session)this.session, false, false);
+            l.DeleteTemporaryCustomization(o, (Session)this.session, tempId);
             Thread.Sleep(1000);
             CheckTM();
         }
@@ -166,7 +165,8 @@ namespace CustomizationEditor
                 }*/
             }
             l.LaunchInEpicor(o, (Session)this.session, true, true);
-            
+
+
             if (o.Key2.Contains("MainController"))//Dashboard
             {
                 l.DownloadAndSyncDashboard((Session)this.session, o);

--- a/CustomizationEditor_10.2.400/NonModalWokIt.Designer.cs
+++ b/CustomizationEditor_10.2.400/NonModalWokIt.Designer.cs
@@ -95,7 +95,6 @@
             this.btnTest.TabIndex = 4;
             this.btnTest.Text = "Run (Test)";
             this.btnTest.UseVisualStyleBackColor = true;
-            this.btnTest.Visible = false;
             this.btnTest.Click += new System.EventHandler(this.btnTest_Click);
             // 
             // btnDebug

--- a/CustomizationEditor_10.2.400/NonModalWokIt.cs
+++ b/CustomizationEditor_10.2.400/NonModalWokIt.cs
@@ -69,12 +69,11 @@ namespace CustomizationEditor
 
         private void btnTest_Click(object sender, EventArgs e)
         {
-            if (chkSyncUp.Checked)
-            {
-                l.UpdateCustomization(o, (Session)this.session);
-            }
-
+            string tempId = "_" + Guid.NewGuid().ToString().Substring(0, o.Key1.Length - 1);
+            l.CreateTemporaryCustomization(o, (Session)this.session, tempId);
+            o.Key1 = o.Key1 + tempId;
             l.LaunchInEpicor(o, (Session)this.session, false, false);
+            l.DeleteTemporaryCustomization(o, (Session)this.session, tempId);
             Thread.Sleep(1000);
             CheckTM();
         }


### PR DESCRIPTION
- The 'Test' button was made visible and repurposed for this behavior.
- Functions were added in common code to create temporary customizations and delete them.