### PR TITLE
Revised the Visual Studio Project auto save logic

### DIFF
--- a/CustomizationEditor_10.1.500/NonModalWokIt.cs
+++ b/CustomizationEditor_10.1.500/NonModalWokIt.cs
@@ -143,12 +143,16 @@ namespace CustomizationEditor
                 }
                 else
                 {
-                     var hWnd = System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle;
+                    // Test for the Visual Studio Project saving only if this is being run from the full Visual Studio.
+                    // We can tell by looking for the presence of alert.txt (which is created only for the VS Code extension)
+                    if (!System.IO.File.Exists($@"{o.ProjectFolder}\alert.txt")) {
+                        var hWnd = System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle;
 
-                    var handle = GetStdHandle(STD_INPUT_HANDLE);
-                    CancelIoEx(handle, IntPtr.Zero);
-                    CancelIoEx(hWnd, IntPtr.Zero);
-                    MessageBox.Show("The Visual Studio Project failed to save automatically in the alloted time, please go manually save your project and click OK when ready. Clicking OK wihtout saving will cause your pending data to be deleted!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        var handle = GetStdHandle(STD_INPUT_HANDLE);
+                        CancelIoEx(handle, IntPtr.Zero);
+                        CancelIoEx(hWnd, IntPtr.Zero);
+                        MessageBox.Show("The Visual Studio Project failed to save automatically in the alloted time, please go manually save your project and click OK when ready. Clicking OK wihtout saving will cause your pending data to be deleted!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    }
                     l.UpdateCustomization(o, (Session)this.session);
                 }
 

--- a/CustomizationEditor_10.1.600/NonModalWokIt.cs
+++ b/CustomizationEditor_10.1.600/NonModalWokIt.cs
@@ -143,12 +143,16 @@ namespace CustomizationEditor
                 }
                 else
                 {
-                     var hWnd = System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle;
+                    // Test for the Visual Studio Project saving only if this is being run from the full Visual Studio.
+                    // We can tell by looking for the presence of alert.txt (which is created only for the VS Code extension)
+                    if (!System.IO.File.Exists($@"{o.ProjectFolder}\alert.txt")) {
+                        var hWnd = System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle;
 
-                    var handle = GetStdHandle(STD_INPUT_HANDLE);
-                    CancelIoEx(handle, IntPtr.Zero);
-                    CancelIoEx(hWnd, IntPtr.Zero);
-                    MessageBox.Show("The Visual Studio Project failed to save automatically in the alloted time, please go manually save your project and click OK when ready. Clicking OK wihtout saving will cause your pending data to be deleted!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        var handle = GetStdHandle(STD_INPUT_HANDLE);
+                        CancelIoEx(handle, IntPtr.Zero);
+                        CancelIoEx(hWnd, IntPtr.Zero);
+                        MessageBox.Show("The Visual Studio Project failed to save automatically in the alloted time, please go manually save your project and click OK when ready. Clicking OK wihtout saving will cause your pending data to be deleted!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    }
                     l.UpdateCustomization(o, (Session)this.session);
                 }
 

--- a/CustomizationEditor_10.2.100/NonModalWokIt.cs
+++ b/CustomizationEditor_10.2.100/NonModalWokIt.cs
@@ -143,12 +143,16 @@ namespace CustomizationEditor
                 }
                 else
                 {
-                     var hWnd = System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle;
+                    // Test for the Visual Studio Project saving only if this is being run from the full Visual Studio.
+                    // We can tell by looking for the presence of alert.txt (which is created only for the VS Code extension)
+                    if (!System.IO.File.Exists($@"{o.ProjectFolder}\alert.txt")) {
+                        var hWnd = System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle;
 
-                    var handle = GetStdHandle(STD_INPUT_HANDLE);
-                    CancelIoEx(handle, IntPtr.Zero);
-                    CancelIoEx(hWnd, IntPtr.Zero);
-                    MessageBox.Show("The Visual Studio Project failed to save automatically in the alloted time, please go manually save your project and click OK when ready. Clicking OK wihtout saving will cause your pending data to be deleted!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        var handle = GetStdHandle(STD_INPUT_HANDLE);
+                        CancelIoEx(handle, IntPtr.Zero);
+                        CancelIoEx(hWnd, IntPtr.Zero);
+                        MessageBox.Show("The Visual Studio Project failed to save automatically in the alloted time, please go manually save your project and click OK when ready. Clicking OK wihtout saving will cause your pending data to be deleted!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    }
                     l.UpdateCustomization(o, (Session)this.session);
                 }
 

--- a/CustomizationEditor_10.2.200/NonModalWokIt.cs
+++ b/CustomizationEditor_10.2.200/NonModalWokIt.cs
@@ -143,12 +143,16 @@ namespace CustomizationEditor
                 }
                 else
                 {
-                     var hWnd = System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle;
+                    // Test for the Visual Studio Project saving only if this is being run from the full Visual Studio.
+                    // We can tell by looking for the presence of alert.txt (which is created only for the VS Code extension)
+                    if (!System.IO.File.Exists($@"{o.ProjectFolder}\alert.txt")) {
+                        var hWnd = System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle;
 
-                    var handle = GetStdHandle(STD_INPUT_HANDLE);
-                    CancelIoEx(handle, IntPtr.Zero);
-                    CancelIoEx(hWnd, IntPtr.Zero);
-                    MessageBox.Show("The Visual Studio Project failed to save automatically in the alloted time, please go manually save your project and click OK when ready. Clicking OK wihtout saving will cause your pending data to be deleted!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        var handle = GetStdHandle(STD_INPUT_HANDLE);
+                        CancelIoEx(handle, IntPtr.Zero);
+                        CancelIoEx(hWnd, IntPtr.Zero);
+                        MessageBox.Show("The Visual Studio Project failed to save automatically in the alloted time, please go manually save your project and click OK when ready. Clicking OK wihtout saving will cause your pending data to be deleted!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    }
                     l.UpdateCustomization(o, (Session)this.session);
                 }
 

--- a/CustomizationEditor_10.2.300/NonModalWokIt.cs
+++ b/CustomizationEditor_10.2.300/NonModalWokIt.cs
@@ -143,12 +143,18 @@ namespace CustomizationEditor
                 }
                 else
                 {
-                     var hWnd = System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle;
 
-                    var handle = GetStdHandle(STD_INPUT_HANDLE);
-                    CancelIoEx(handle, IntPtr.Zero);
-                    CancelIoEx(hWnd, IntPtr.Zero);
-                    MessageBox.Show("The Visual Studio Project failed to save automatically in the alloted time, please go manually save your project and click OK when ready. Clicking OK wihtout saving will cause your pending data to be deleted!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    // Test for the Visual Studio Project saving only if this is being run from the full Visual Studio.
+                    // We can tell by looking for the presence of alert.txt (which is created only for the VS Code extension)
+                    if (!System.IO.File.Exists($@"{o.ProjectFolder}\alert.txt")) {
+                        var hWnd = System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle;
+
+                        var handle = GetStdHandle(STD_INPUT_HANDLE);
+                        CancelIoEx(handle, IntPtr.Zero);
+                        CancelIoEx(hWnd, IntPtr.Zero);
+                        MessageBox.Show("The Visual Studio Project failed to save automatically in the alloted time, please go manually save your project and click OK when ready. Clicking OK wihtout saving will cause your pending data to be deleted!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    }
+
                     l.UpdateCustomization(o, (Session)this.session);
                 }
 

--- a/CustomizationEditor_10.2.400/NonModalWokIt.cs
+++ b/CustomizationEditor_10.2.400/NonModalWokIt.cs
@@ -143,12 +143,16 @@ namespace CustomizationEditor
                 }
                 else
                 {
-                     var hWnd = System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle;
+                    // Test for the Visual Studio Project saving only if this is being run from the full Visual Studio.
+                    // We can tell by looking for the presence of alert.txt (which is created only for the VS Code extension)
+                    if (!System.IO.File.Exists($@"{o.ProjectFolder}\alert.txt")) {
+                        var hWnd = System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle;
 
-                    var handle = GetStdHandle(STD_INPUT_HANDLE);
-                    CancelIoEx(handle, IntPtr.Zero);
-                    CancelIoEx(hWnd, IntPtr.Zero);
-                    MessageBox.Show("The Visual Studio Project failed to save automatically in the alloted time, please go manually save your project and click OK when ready. Clicking OK wihtout saving will cause your pending data to be deleted!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        var handle = GetStdHandle(STD_INPUT_HANDLE);
+                        CancelIoEx(handle, IntPtr.Zero);
+                        CancelIoEx(hWnd, IntPtr.Zero);
+                        MessageBox.Show("The Visual Studio Project failed to save automatically in the alloted time, please go manually save your project and click OK when ready. Clicking OK wihtout saving will cause your pending data to be deleted!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    }
                     l.UpdateCustomization(o, (Session)this.session);
                 }
 


### PR DESCRIPTION
Revised the Visual Studio Project auto save logic:
- Now only runs when alert.txt is NOT present.
- This causes is to not bug users of VS Code.