### PR TITLE
Removed 'Failed to Authenticate' message

### DIFF
--- a/CommonCode/Program.cs
+++ b/CommonCode/Program.cs
@@ -370,9 +370,7 @@ namespace CustomizationEditor
             catch (Exception ex)
             {
                 Log.Error(ex,$"Failed to Login");
-                ShowProgressBar(false);
-                MessageBox.Show("Failed to Authenticate","Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                
+                ShowProgressBar(false);                
                 
                 LoginForm frm = new LoginForm(o.EpicorClientFolder);
                 if (frm.ShowDialog() == DialogResult.OK)


### PR DESCRIPTION
- Putting this is as its own pull request knowing this may be a topic for conversation.
- CustomizationInfo.json is a required file to run customizations but in a multi-user, Git-controlled setup we don't want the user / password in that file.
- Everything works if those values are excluded from the file, but we will get the 'Failed To Authenticate' before the login prompt.
- It is ENTIRELTY possibly I have missed the boat on something here.