### PR TITLE
Add support for customization on Report forms

### DIFF
--- a/CommonCode/EpicorLauncher.cs
+++ b/CommonCode/EpicorLauncher.cs
@@ -150,7 +150,7 @@ namespace CommonCode
                     }
                 }
             var typeE = assy.DefinedTypes.Where(r => r.FullName.ToUpper().Contains(o.Key2.ToUpper())).FirstOrDefault();
-            var typeTList = assy.DefinedTypes.Where(r => r.BaseType.Name.Equals("EpiTransaction") || r.BaseType.Name.Equals("EpiMultiViewTransaction") || r.BaseType.Name.Equals("EpiSingleViewTransaction") || r.BaseType.Name.Equals("UDMultiViewTransaction") || r.BaseType.Name.Equals("UDSingleViewTransaction")).ToList();
+            var typeTList = assy.DefinedTypes.Where(r => r.BaseType.Name.Equals("EpiTransaction") || r.BaseType.Name.Equals("EpiMultiViewTransaction") || r.BaseType.Name.Equals("EpiSingleViewTransaction") || r.BaseType.Name.Equals("UDMultiViewTransaction") || r.BaseType.Name.Equals("UDSingleViewTransaction") ||  r.BaseType.Name.Equals("EpiReportTransaction")).ToList();
             if (typeTList != null && typeTList.Count > 0)
                 foreach (var typeT in typeTList)
                 {
@@ -510,7 +510,7 @@ namespace CommonCode
                 s = assy.Location;
                 var typeE = assy.DefinedTypes.Where(r => r.FullName.ToUpper().Contains(o.Key2.ToUpper())).FirstOrDefault();
 
-                var typeTList = assy.DefinedTypes.Where(r => r.BaseType.Name.Equals("EpiTransaction") || r.BaseType.Name.Equals("EpiMultiViewTransaction") || r.BaseType.Name.Equals("EpiSingleViewTransaction") || r.BaseType.Name.Equals("UDMultiViewTransaction") || r.BaseType.Name.Equals("UDSingleViewTransaction")).ToList();
+                var typeTList = assy.DefinedTypes.Where(r => r.BaseType.Name.Equals("EpiTransaction") || r.BaseType.Name.Equals("EpiMultiViewTransaction") || r.BaseType.Name.Equals("EpiSingleViewTransaction") || r.BaseType.Name.Equals("UDMultiViewTransaction") || r.BaseType.Name.Equals("UDSingleViewTransaction") || r.BaseType.Name.Equals("EpiReportTransaction")).ToList();
                 if (typeTList != null && typeTList.Count > 0)
                     foreach (var typeT in typeTList)
                     {


### PR DESCRIPTION
When I tried to run the extension to edit a customisation on Client Statment (which is a Report UI Form), the customisation didn't load. After opening up the log file, I found that the error was at DownloadAndSync() method, with invalid cast exception (casting Ice.Lib.Framework.EpiTransaction to Erp.Rpt.AC_ClientStatement.Transaction)

I found that this code here didn't account for the fact that the BaseType of Reports are EpiReportTransaction.
```
var typeTList = assy.DefinedTypes.Where(r => r.BaseType.Name.Equals("EpiTransaction") || r.BaseType.Name.Equals("EpiMultiViewTransaction") || r.BaseType.Name.Equals("EpiSingleViewTransaction") || r.BaseType.Name.Equals("UDMultiViewTransaction") || r.BaseType.Name.Equals("UDSingleViewTransaction")).ToList();
                if (typeTList != null && typeTList.Count > 0)
                    foreach (var typeT in typeTList)
                    {
                        try
                        {
                            if (typeT != null)
                                epiTransaction = Activator.CreateInstance(typeT, new object[] { oTrans });
                            else
                                epiTransaction = new EpiTransaction(oTrans);

                            epiBaseForm = Activator.CreateInstance(typeE, new object[] { epiTransaction });
                            break;
                        }
                        catch (Exception)
                        { }
                    }
                else
                {
                    epiTransaction = new EpiTransaction(oTrans);
                    epiBaseForm = Activator.CreateInstance(typeE, new object[] { epiTransaction }); //<-- This is where the error happened
                }
```

After adding the EpiReportTransaction as part of the BaseType, the CustomizationEditor can load the customisation on Client Statement. I also found another instance of this code in the GetCSM, which also didn't have EpiReportTransaction as part of the Where clause. Technically, the same error can happen too.

I've built my own CustomizationEditor with the updated code and it worked.